### PR TITLE
Fix macos cert file detection

### DIFF
--- a/lib/ca_certs.ml
+++ b/lib/ca_certs.ml
@@ -43,8 +43,7 @@ let openbsd_location = "/etc/ssl/cert.pem"
 
 let freebsd_location = "/usr/local/share/certs/ca-root-nss.crt"
 
-let macos_keychain_location =
-  "/System/Library/Keychains/SystemRootCertificates.keychain"
+let macos_location = "/etc/ssl/cert.pem"
 
 let ta_file_raw () =
   let open Rresult.R.Infix in
@@ -56,15 +55,7 @@ let ta_file_raw () =
     | "FreeBSD" -> detect_one freebsd_location
     | "OpenBSD" -> detect_one openbsd_location
     | "Linux" -> detect_list linux_locations
-    | "Darwin" ->
-        let cmd =
-          Bos.Cmd.(
-            v "security" % "find-certificate" % "-a" % "-p"
-            % macos_keychain_location)
-        in
-        let tmpfile = Fpath.v (Filename.temp_file "cacert" "pem") in
-        Bos.OS.Cmd.(run_out cmd |> out_file tmpfile |> success) >>| fun () ->
-        tmpfile
+    | "Darwin" -> detect_one macos_location
     | s -> Error (`Msg ("ca-certs: unknown system " ^ s ^ ".\n" ^ issue))
 
 let trust_anchor_filename () =


### PR DESCRIPTION
This PR should fix the issue occurring in https://github.com/ocaml/opam-repository/pull/17391.

The problem is that the macos sandbox does not allow `security find-certificate` to run properly (I'm guessing internally it's trying to write into a log file or something like that) and will output nothing.
Using `/etc/ssl/cert.pem` worked on my freshly installed macos 10.15 (Catalina) so given all the other distributions are given the same sort of hardcoded file, it seems to me like a more logical choice. Plus I feel like creating a temporary file (even if it would have been deleted afterwards) is not so great for a library.