### PR TITLE
More resilient in respect to certificate decoding failures

### DIFF
--- a/ca-certs.opam
+++ b/ca-certs.opam
@@ -14,10 +14,12 @@ doc: "https://mirage.github.io/ca-certs/doc"
 bug-reports: "https://github.com/mirage/ca-certs/issues"
 depends: [
   "dune" {>= "2.0"}
+  "astring"
   "bos"
   "fpath"
   "rresult"
   "ptime"
+  "logs"
   "mirage-crypto"
   "x509" {>= "0.11.0"}
   "ocaml" {>= "4.07.0"}

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
 (package
  (name ca-certs)
  (depends
-  bos fpath rresult ptime mirage-crypto
+  astring bos fpath rresult ptime logs mirage-crypto
   (x509 (>= 0.11.0))
   (ocaml (>= 4.07.0))
   (alcotest :with-test))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name ca_certs)
  (public_name ca-certs)
- (libraries mirage-crypto x509 bos rresult fpath ptime.clock.os))
+ (libraries mirage-crypto x509 astring bos rresult fpath logs ptime.clock.os))


### PR DESCRIPTION
Some trust anchor collections may contain certificates that X509 cannot decode
(see mirage/ocaml-x509#137 - ECC certificates). With this commit, such
certificates that fail to be decoded are reported (using the Logs library) and
ignored. In the case the trust anchors are empty, the authenticator function
errors.