### PR TITLE
Windows support

### DIFF
--- a/lib/ca_certs_stubs.c
+++ b/lib/ca_certs_stubs.c
@@ -1,0 +1,49 @@
+#include "caml/alloc.h"
+#include "caml/callback.h"
+#include "caml/fail.h"
+#include "caml/memory.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+value ca_certs_iter_on_anchors(value v_f)
+{
+    CAMLparam1(v_f);
+    CAMLlocal1(v_encoded_cert);
+
+    HCERTSTORE hCertStore = CertOpenSystemStore(0, "ROOT");
+    if (!hCertStore)
+    {
+        caml_failwith("ca_certs_iter_on_anchors: CertOpenSystemStore returned NULL");
+    }
+
+    PCCERT_CONTEXT pCertContext = NULL;
+    while ((pCertContext = CertEnumCertificatesInStore(hCertStore, pCertContext)) != NULL)
+    {
+        if (!(pCertContext->dwCertEncodingType & X509_ASN_ENCODING))
+        {
+            caml_failwith("ca_certs_iter_on_anchors: certificate does not have expected encoding");
+        }
+        v_encoded_cert = caml_alloc_initialized_string(
+            pCertContext->cbCertEncoded,
+            pCertContext->pbCertEncoded);
+        caml_callback(v_f, v_encoded_cert);
+    }
+
+    if (!CertCloseStore(hCertStore, 0))
+    {
+        caml_failwith("ca_certs_iter_on_anchors: CertCloseStore returned an error");
+    }
+
+    CAMLreturn(Val_unit);
+}
+
+#else
+
+value ca_certs_iter_on_anchors(value v_unit)
+{
+    caml_failwith("ca_certs_iter_on_anchors: only implemented on Windows");
+}
+
+#endif

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,27 @@
 (library
  (name ca_certs)
  (public_name ca-certs)
- (libraries mirage-crypto x509 astring bos rresult fpath logs ptime.clock.os))
+ (libraries mirage-crypto x509 astring bos rresult fpath logs ptime.clock.os)
+ (foreign_stubs
+  (language c)
+  (names ca_certs_stubs))
+ (c_library_flags
+  (:include flags.sexp)))
+
+(rule
+ (target flags.sexp)
+ (enabled_if
+  (= %{os_type} Win32))
+ (action
+  (with-stdout-to
+   %{target}
+   (echo "(:standard -lcrypt32)"))))
+
+(rule
+ (target flags.sexp)
+ (enabled_if
+  (<> %{os_type} Win32))
+ (action
+  (with-stdout-to
+   %{target}
+   (echo :standard))))


### PR DESCRIPTION
Closes #14

On Windows, the root certificates are available in the system store named "ROOT". The corresponding certificate contexts hold a DER encoding of the certificates, which is exposed through a C external.

See <https://docs.microsoft.com/en-us/windows/win32/seccrypto/example-c-program-listing-the-certificates-in-a-store>