### PR TITLE
add: additional key path for macos

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version = 0.25.1
+version = 0.26.2
 profile=conventional

--- a/lib/ca_certs.ml
+++ b/lib/ca_certs.ml
@@ -108,19 +108,35 @@ let trust_anchors () =
                      Bos.Cmd.(
                        v "security" % "find-certificate" % "-a" % "-p" % path)
                    in
-                   Bos.OS.Cmd.(
-                     run_out cmd |> out_string |> success |> Result.to_option))
+                   Bos.OS.Cmd.(run_out cmd |> out_string |> success))
             |> List.fold_left
                  (fun acc cert ->
                    match (cert, acc) with
-                   | Some cert, Some acc -> Some (cert ^ "\n" ^ acc)
-                   | Some cert, None -> Some cert
-                   | _ -> acc)
-                 None
-            |> Option.to_result
-                 ~none:
-                   (`Msg
-                     ("ca-certs: no trust anchor file found on macOS.\n" ^ issue))
+                   | Ok cert, Ok acc -> Ok (cert ^ "\n" ^ acc)
+                   | Ok cert, Error (`Msg msg) ->
+                       Log.warn (fun m ->
+                           m
+                             "ignoring error %s (got another set of \
+                              certificates)"
+                             msg);
+                       Ok cert
+                   | Error e, Ok "" -> Error e
+                   | Error (`Msg msg), Ok x ->
+                       Log.warn (fun m ->
+                           m
+                             "ignoring error %s (already have another set of \
+                              certificates)"
+                             msg);
+                       Ok x
+                   | Error e, Error (`Msg msg) ->
+                       Log.warn (fun m ->
+                           m "ignoring error %s (got another error)" msg);
+                       Error e)
+                 (Ok "")
+            |> Result.map_error (function `Msg msg ->
+                   `Msg
+                     ("ca-certs: no trust anchor file found on macOS: " ^ msg
+                    ^ ".\n" ^ issue))
         | s -> Error (`Msg ("ca-certs: unknown system " ^ s ^ ".\n" ^ issue)))
 
 let authenticator ?crls ?allowed_hashes () =


### PR DESCRIPTION
On MacOS it's normal[1] to add custom certificates to `/Library/Keychains/System.keychain` in addition to `/System/Library/Keychains/SystemRootCertificates.keychain`. This PR now checks both locations and concatenates them

[1] https://apple.stackexchange.com/questions/53579/how-is-the-system-keychain-secured-in-os-x