### PR TITLE
Facilitate the use of extra CA certificates

### DIFF
--- a/lib/ca_certs.mli
+++ b/lib/ca_certs.mli
@@ -12,7 +12,12 @@ val authenticator :
 
 val trust_anchors : unit -> (string, [> `Msg of string ]) result
 (** [trust_anchors ()] detects the root CAs (trust anchors) in the operating
-    system's trust store. On Unix systems, if the environment variable
-    [SSL_CERT_FILE] is set, its value is used as path to the trust anchors.
-    Otherwise, if [NIX_SSL_CERT_FILE] is set, its value is used.
+    system's trust store. Additional CAs can be provided by setting the
+    environment variable [OCAML_EXTRA_CA_CERTS] to a filename containing
+    pem-encoded X509 certificates.
+
+    On Unix systems, if the environment variable [SSL_CERT_FILE] is set, its
+    value is used as path to the system trust anchors.  Otherwise, if
+    [NIX_SSL_CERT_FILE] is set, its value is used.
+
     The successful result is a list of pem-encoded X509 certificates. *)


### PR DESCRIPTION
I found the following changes useful to quickly enable exceptional CA certificates when experimenting with Cohttp HTTPS requests to the (untrustworthy) `mitmproxy` for debugging, and to various localhost test servers (with locally generated CA certificates). I'm not entirely sure that this PR behavior is desirable, so I've broken it in two commits:

- One commit to make it easier to parse a certificates file, to eg manually configure Cohttp/Conduit `ctx` => This could also be done through the existing `X509.Certificate.decode_pem_multiple`, with some caveats (perhaps I should propose a fix to x509 instead, to handle failures more gracefully?)
- And one commit to automatically read additional certificates from the environment variable `OCAML_EXTRA_CA_CERTS` file. This has some precedent on other platform, eg `NODE_EXTRA_CA_CERTS` in nodejs, because users can't always install certificates... but it could also be argued that it's a security risk to provide an escape hatch! (but installing a `mitmproxy` CA isn't great either ^^')

I can always configure Cohttp authenticator manually with extra CAs, so feel free to reject this PR!