### PR TITLE
Silent logs

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version = 0.26.2
+version = 0.27.0
 profile=conventional

--- a/lib/ca_certs.ml
+++ b/lib/ca_certs.ml
@@ -16,16 +16,16 @@ let detect_one path =
   | _ ->
       Error
         (`Msg
-          ("ca-certs: no trust anchor file found, looked into " ^ path ^ ".\n"
-         ^ issue))
+           ("ca-certs: no trust anchor file found, looked into " ^ path ^ ".\n"
+          ^ issue))
 
 let detect_list paths =
   let rec one = function
     | [] ->
         Error
           (`Msg
-            ("ca-certs: no trust anchor file found, looked into "
-           ^ String.concat ", " paths ^ ".\n" ^ issue))
+             ("ca-certs: no trust anchor file found, looked into "
+            ^ String.concat ", " paths ^ ".\n" ^ issue))
     | path :: paths -> (
         match detect_one path with Ok data -> Ok data | Error _ -> one paths)
   in
@@ -62,9 +62,9 @@ let get_anchors () =
 
 let ( let* ) = Result.bind
 
-(** Load certificates from Windows' ["ROOT"] system certificate store.
-    The C API returns a list of DER-encoded certificates. These are decoded and
-    reencoded as a single PEM certificate. *)
+(** Load certificates from Windows' ["ROOT"] system certificate store. The C API
+    returns a list of DER-encoded certificates. These are decoded and reencoded
+    as a single PEM certificate. *)
 let windows_trust_anchors () =
   let* anchors = get_anchors () in
   let cert_list, err_count =

--- a/lib/ca_certs.ml
+++ b/lib/ca_certs.ml
@@ -67,18 +67,20 @@ let ( let* ) = Result.bind
     reencoded as a single PEM certificate. *)
 let windows_trust_anchors () =
   let* anchors = get_anchors () in
-  let cert_list =
+  let cert_list, err_count =
     List.fold_left
-      (fun acc cert ->
+      (fun (acc, err_count) cert ->
         match X509.Certificate.decode_der cert with
-        | Ok cert -> cert :: acc
+        | Ok cert -> (cert :: acc, err_count)
         | Error (`Msg msg) ->
-            Log.warn (fun m -> m "Ignoring undecodable trust anchor: %s." msg);
+            Log.debug (fun m -> m "Ignoring undecodable trust anchor: %s." msg);
             Log.debug (fun m ->
                 m "Full certificate:@.%a" (Ohex.pp_hexdump ()) cert);
-            acc)
-      [] anchors
+            (acc, err_count + 1))
+      ([], 0) anchors
   in
+  if err_count > 0 then
+    Log.warn (fun m -> m "Ignored %u trust anchors." err_count);
   Ok (X509.Certificate.encode_pem_multiple cert_list)
 
 let system_trust_anchors () =
@@ -89,10 +91,10 @@ let system_trust_anchors () =
       (Sys.getenv_opt "SSL_CERT_FILE", Sys.getenv_opt "NIX_SSL_CERT_FILE")
     with
     | Some x, _ ->
-        Log.info (fun m -> m "using %s (from SSL_CERT_FILE)" x);
+        Log.debug (fun m -> m "using %s (from SSL_CERT_FILE)" x);
         detect_one x
     | _, Some x ->
-        Log.info (fun m -> m "using %s (from NIX_SSL_CERT_FILE)" x);
+        Log.debug (fun m -> m "using %s (from NIX_SSL_CERT_FILE)" x);
         detect_one x
     | None, None -> (
         let cmd = Bos.Cmd.(v "uname" % "-s") in
@@ -156,13 +158,18 @@ let trust_anchors () =
       Ok cas
 
 let decode_pem_multiple data =
-  X509.Certificate.fold_decode_pem_multiple
-    (fun acc -> function
-      | Ok t -> t :: acc
-      | Error (`Msg msg) ->
-          Log.warn (fun m -> m "Ignoring undecodable trust anchor: %s." msg);
-          acc)
-    [] data
+  let tas, err_count =
+    X509.Certificate.fold_decode_pem_multiple
+      (fun (acc, err_count) -> function
+        | Ok t -> (t :: acc, err_count)
+        | Error (`Msg msg) ->
+            Log.debug (fun m -> m "Ignoring undecodable trust anchor: %s." msg);
+            (acc, err_count + 1))
+      ([], 0) data
+  in
+  if err_count > 0 then
+    Log.warn (fun m -> m "Ignored %u trust anchors." err_count);
+  tas
 
 let authenticator ?crls ?allowed_hashes () =
   let* data = trust_anchors () in

--- a/lib/ca_certs.mli
+++ b/lib/ca_certs.mli
@@ -7,8 +7,8 @@ val authenticator :
     anchors) in the operating system's trust store using {!trust_anchors}. It
     constructs an authenticator with the current timestamp {!Ptime_clock.now},
     and the provided [~crls] and [~allowed_hashes] arguments. The resulting
-    authenticator can be used for {!Tls.Config.client}.
-    Returns [Error `Msg msg] if detection did not succeed. *)
+    authenticator can be used for {!Tls.Config.client}. Returns [Error `Msg msg]
+    if detection did not succeed. *)
 
 val trust_anchors : unit -> (string, [> `Msg of string ]) result
 (** [trust_anchors ()] detects the root CAs (trust anchors) in the operating
@@ -17,7 +17,7 @@ val trust_anchors : unit -> (string, [> `Msg of string ]) result
     pem-encoded X509 certificates.
 
     On Unix systems, if the environment variable [SSL_CERT_FILE] is set, its
-    value is used as path to the system trust anchors.  Otherwise, if
+    value is used as path to the system trust anchors. Otherwise, if
     [NIX_SSL_CERT_FILE] is set, its value is used.
 
     The successful result is a list of pem-encoded X509 certificates. *)


### PR DESCRIPTION
I don't want to see what the ca-certs library does in my logs because it's generally too complex for me to understand and it generally just works.

The errors generated by `fold_decode_pem_multiple` are especially problematic because I cannot do anything about them and the authenticator works as intended anyway.

On NixOS, this message is repeated 175 times each time an authenticator is created:

    my_app: [WARNING] Ignoring undecodable trust anchor: ignore non certificate.